### PR TITLE
feat: support for configuring dependency constraint strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ the dependency will be rewritten as if it had been defined as:
 b = "^1.2.3"
 ```
 
+## Configuration
+
+You can define a section in your `pyproject.toml` file named `tool.stickywheel`, to configure various options.
+
+### Dependency constraint strategy
+
+The default strategy is `semver` (described in the "Help" section above), but there are other choices:
+
+| strategy  | version | result    |
+|-----------|---------|-----------|
+| `semver`  | `1.2.3` | `^1.2.3`  |
+| `minimum` | `1.2.3` | `>=1.2.3` |
+| `exact`   | `1.2.3` | `1.2.3`   |
+
+To override the default, add `strategy` to the configuration. For example:
+
+```toml
+[tool.stickywheel]
+strategy = "exact"
+```
+
 ## ⚖️ Licence
 
 This project is licensed under the [MIT licence][mit_licence].


### PR DESCRIPTION
## Description

To resolve #5 

I also renamed a variable in `pin_dependency()` to reduce confusion about which `pyproject.toml` file is in use. This is because we now care about the root `pyproject.toml` file in addition to those of the project's dependencies.

## Motivation and Context

I would love to make use of the functionality described in #5 

## How Has This Been Tested?

I installed poetry and this plugin into the same virtualenv as my monorepo is installed in. I then ran `poetry build --format=wheel` and manually inspected the generated wheel.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

